### PR TITLE
first release

### DIFF
--- a/.collectignore.sample
+++ b/.collectignore.sample
@@ -1,0 +1,5 @@
+# .collectignore の例
+dist/
+*.pyc
+.DS_Store
+docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-
-__pycache__/
-
-.idea/
-
-.collectignore
+venv/
 *.txt
 !requirements.txt
+__pycache__/
+.idea
+.collectignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+__pycache__/
+
+.idea/
+
+.collectignore
+*.txt
+!requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
 # repo-collector
+
+GitHub の指定リポジトリからすべてのファイルを取得し、1つのテキストファイルにまとめるツールです。  
+学習目的で作成したものであり、**本ツールを使用したことによるいかなる結果についても一切の責任を負いません**。  
+ご利用の際は、プログラムや取得するリポジトリのライセンスを含め、各種規約を十分にご確認ください。
+
+---
+
+## 注意事項
+
+- **APIレートリミット**: GitHub の API を多数コールするため、レートリミットに達する場合があります。現状はその対策を行っていないので、レートリミットにかかった場合は時間をおいて再度実行してください（TODO: レートリミット対策の検討）。
+- **利用範囲**: 学習目的を想定しています。取得するコードのライセンスや、他人の権利を侵害しないようご注意ください。
+- **免責**: 本ソフトウェアを使用したことによって発生した損害・不具合・トラブルなど、いかなる事象についても作成者は責任を負いかねます。自己責任のもとでご利用ください。
+
+---
+
+## セットアップ & 使い方
+
+1. **リポジトリのクローンまたはダウンロード**
+
+   ```bash
+   git clone https://github.com/Yulikepython/repo-collector.git
+   cd repo-collector
+   ```
+
+2. **必要ライブラリのインストール**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+   > ※ 仮想環境（`venv/`）などを用意して利用することをおすすめします。
+
+3. **.collectignore.sample について（任意）**  
+   特定の拡張子やパスを取得したくない場合は、同梱の `.collectignore.sample` を参考にして  
+   ```bash
+   cp .collectignore.sample .collectignore
+   ```
+   などで `.collectignore` を作成し、無視したいパターンを追記してください。
+
+4. **実行方法**  
+   - **`--dir` オプションは省略可能** です。指定しない場合、カレントディレクトリを出力先とします。
+   - 例: リポジトリ [psf/requests](https://github.com/psf/requests) を取得し、カレントディレクトリに `summary-requests.txt` を出力する場合:
+     
+     ```bash
+     python main.py --url https://github.com/psf/requests
+     ```
+     
+     カレントディレクトリ以外を指定したい場合:
+     ```bash
+     python main.py --url https://github.com/psf/requests --dir /path/to/output
+     ```
+     
+     `repo_collector.py` は単体でも動作しますが、`.collectignore` 等を利用した無視パターン機能は含まれない点にご注意ください。
+
+5. **出力ファイル**  
+   - 実行後、指定ディレクトリ（省略時はカレントディレクトリ）に `summary-リポジトリ名.txt` の形式でファイルが作成されます。  
+   - 取得した各ファイルの内容を、`# ===== File: ファイルパス =====` の見出しコメント付きで連結したテキストが出力されます。
+
+---
+
+## ディレクトリ構成
+
+```
+repo-collector/
+├─ repo_collector.py   # 単体でも動作するメインスクリプト
+├─ services.py         # APIコールなどのサービス層
+├─ controller.py       # 引数パースと全体の制御
+├─ main.py             # controllerを利用した実行入口
+├─ ignore_manager.py   # .collectignoreを読み込み、無視すべきパスを判定
+├─ venv/               # (任意) 仮想環境用フォルダ
+├─ .collectignore.sample  # ignoreしたいパターンのサンプル
+├─ requirements.txt    # インストールが必要なライブラリ一覧
+└─ README.md           # 本ファイル
+```
+
+---
+
+## TODO
+
+- [ ] **レートリミット回避策**: GitHub のトークン認証（Personal Access Token の使用）やリクエスト間隔の調整などの対応を検討。
+- [ ] **フィルタリング強化**: 取得したいファイルの種類を指定したり、取得しないディレクトリをまとめて除外したりする機能。
+- [ ] **出力形式の拡張**: テキストファイル以外のフォーマットへの出力（Markdown、HTML など）も検討。
+
+---
+
+## ライセンス / License
+
+本リポジトリは [MIT License](./LICENSE) のもとで公開されています。  
+ご利用の際は、[MIT ライセンス](./LICENSE)をご確認ください。
+
+---
+
+**Disclaimer**: This software is provided "as is", without warranty of any kind, express or implied.  
+Use it at your own risk.  

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,53 @@
+import argparse
+import os
+from services import merge_repo_code
+from ignore_manager import load_ignore_patterns
+
+
+def run_controller():
+    """
+    コマンドライン引数をパースして、指定されたGitHubリポジトリのコードを1ファイルにまとめる。
+    .collectignore (あれば) を読み込んで無視パターンとして適用する。
+    """
+    parser = argparse.ArgumentParser(
+        description="GitHubリポジトリからファイルをまとめて1つのテキストファイルに出力するツール"
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="対象のGitHubリポジトリURL (例: https://github.com/psf/requests)"
+    )
+    parser.add_argument(
+        "--dir",
+        default=None,  # Noneの場合は後でデフォルト設定
+        help="出力ファイルの作成先ディレクトリ。指定がない場合はカレントディレクトリ。"
+    )
+
+    args = parser.parse_args()
+    repo_url = args.url
+
+    # --dir が None ならカレントディレクトリを使用
+    output_dir = args.dir if args.dir is not None else "."
+
+    # .collectignore をロード
+    ignore_patterns = load_ignore_patterns(".collectignore")
+
+    print(f"Target Repo: {repo_url}")
+    if ignore_patterns:
+        print(f"Ignore patterns: {ignore_patterns}")
+    else:
+        print("No ignore patterns found.")
+
+    # リポジトリの全ファイルを結合
+    repo_name, merged_text = merge_repo_code(repo_url, ignore_patterns)
+
+    # 出力ファイル名例: "summary-requests.txt"
+    output_filename = f"summary-{repo_name}.txt"
+    output_path = os.path.join(output_dir, output_filename)
+
+    # テキストを書き出し
+    os.makedirs(output_dir, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(merged_text)
+
+    print(f"Created: {output_path}")

--- a/ignore_manager.py
+++ b/ignore_manager.py
@@ -1,0 +1,58 @@
+import os
+import fnmatch
+
+# ここで「デフォルトで無視したい拡張子」を定義しておく
+DEFAULT_IGNORE_EXTENSIONS = [
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".pdf",
+    ".zip",
+    ".exe",
+    # 必要に応じて追加
+]
+
+def load_ignore_patterns(ignore_file: str = ".collectignore") -> list:
+    """
+    .collectignore に記載された無視パターンをリストとして返す。
+    ファイルが存在しない場合は空リストを返す。
+    加えて、DEFAULT_IGNORE_EXTENSIONS も無視パターンとして自動的に追加する。
+    """
+    patterns = []
+
+    # ユーザ定義の .collectignore があれば読み込む
+    if os.path.exists(ignore_file):
+        with open(ignore_file, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                # 空行やコメント(#)行は無視
+                if not line or line.startswith('#'):
+                    continue
+                patterns.append(line)
+
+    # デフォルト拡張子を ignore パターンとして追加 (例: *.png, *.jpg, ...)
+    for ext in DEFAULT_IGNORE_EXTENSIONS:
+        pattern = f"*{ext}"  # 例: "*.png"
+        if pattern not in patterns:  # 重複登録を防ぐ
+            patterns.append(pattern)
+
+    return patterns
+
+
+def is_ignored(path: str, patterns: list) -> bool:
+    """
+    渡されたパスが、ignoreパターンのいずれかにマッチしたらTrueを返す。
+    fnmatchを使用してワイルドカードマッチングを行う。
+    例:
+        patterns = ["dist/", "*.pyc", ".DS_Store", "*.png", ...]
+        path = "dist/setup.py" -> True
+        path = "setup.pyc" -> True
+        path = "images/logo.png" -> True
+        path = "src/main.py" -> False
+    """
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False

--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+repo-collector
+--------------
+GitHubの指定リポジトリからコードを取得して、1つのテキストファイルにまとめるツール。
+
+[Usage Example]
+    python main.py --url https://github.com/psf/requests --dir .
+"""
+
+from controller import run_controller
+
+if __name__ == "__main__":
+    run_controller()

--- a/repo_collector.py
+++ b/repo_collector.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+repo-collector
+--------------
+GitHubの指定リポジトリからコードを取得して、1つのテキストファイルにまとめるツール。
+
+[Usage Example]
+    python repo_collector.py --url https://github.com/psf/requests --dir .
+"""
+
+import argparse
+import os
+import requests
+
+
+def get_repo_owner_and_name(repo_url: str):
+    """
+    GitHubリポジトリのURLからオーナー名とリポジトリ名を抽出する関数。
+    例: "https://github.com/username/repo" -> ("username", "repo")
+    """
+    repo_url = repo_url.rstrip('/')
+    parts = repo_url.split('/')
+    if len(parts) < 5:
+        raise ValueError("無効なGitHubリポジトリURLです。例: https://github.com/username/repo")
+    owner = parts[-2]
+    repo = parts[-1]
+    return owner, repo
+
+
+def fetch_repo_files(owner: str, repo: str, path: str = ""):
+    """
+    指定されたowner/repoの指定パス内のコンテンツ情報を取得し、
+    再帰的にすべてのファイル（typeが'file'の項目）のリストを返す関数。
+
+    GitHub API:
+      https://api.github.com/repos/{owner}/{repo}/contents/{path}
+    """
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    response = requests.get(api_url)
+    response.raise_for_status()
+    items = response.json()
+
+    files = []
+    for item in items:
+        if item['type'] == 'file':
+            files.append(item)
+        elif item['type'] == 'dir':
+            files.extend(fetch_repo_files(owner, repo, item['path']))
+    return files
+
+
+def fetch_file_content(file_info: dict) -> str:
+    """
+    GitHub APIから取得したファイル情報（file_info）に含まれるdownload_urlを使って
+    ファイル内容を取得し返す関数。
+    """
+    download_url = file_info.get('download_url')
+    if not download_url:
+        return ""
+    resp = requests.get(download_url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def merge_repo_code(repo_url: str) -> (str, str):
+    """
+    指定されたGitHubリポジトリURLからすべてのファイルを取得し、
+    ファイルごとにコメント行を挿入してまとめた文字列を作成して返す関数。
+
+    Returns:
+        (repo_name, merged_text)
+         repo_name: リポジトリ名(例: "requests")
+         merged_text: すべてのファイル内容をまとめたテキスト
+    """
+    owner, repo_name = get_repo_owner_and_name(repo_url)
+    files = fetch_repo_files(owner, repo_name)
+
+    merged_text = []
+    for file_info in files:
+        path = file_info.get('path', 'unknown')
+        try:
+            content = fetch_file_content(file_info)
+        except Exception as e:
+            print(f"[Warning] {path} の取得に失敗: {e}")
+            continue
+
+        merged_text.append(f"\n\n# ===== File: {path} =====\n\n{content}")
+
+    return repo_name, "".join(merged_text)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="GitHubリポジトリから全ファイルをまとめて1つのテキストファイルに出力するツール"
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="対象のGitHubリポジトリURL (例: https://github.com/psf/requests)"
+    )
+    parser.add_argument(
+        "--dir",
+        default=".",
+        help="出力ファイルの作成先ディレクトリ (default: カレントディレクトリ)"
+    )
+
+    args = parser.parse_args()
+    repo_url = args.url
+    output_dir = args.dir
+
+    # リポジトリの全ファイルをまとめて取得
+    print(f"Target Repo: {repo_url}")
+    repo_name, merged_text = merge_repo_code(repo_url)
+
+    # 出力ファイル名: "summary-<repo_name>.txt"
+    #  例: "summary-requests.txt"
+    output_filename = f"summary-{repo_name}.txt"
+    output_path = os.path.join(output_dir, output_filename)
+
+    # テキストを書き出し
+    os.makedirs(output_dir, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(merged_text)
+
+    print(f"Created: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2025.1.31
+charset-normalizer==3.4.1
+idna==3.10
+requests==2.32.3
+urllib3==2.3.0

--- a/services.py
+++ b/services.py
@@ -1,0 +1,83 @@
+import requests
+from ignore_manager import is_ignored
+
+
+def get_repo_owner_and_name(repo_url: str):
+    """
+    GitHubリポジトリURLから (オーナー名, リポジトリ名) を抽出。
+    例: "https://github.com/username/repo" -> ("username", "repo")
+    """
+    repo_url = repo_url.rstrip('/')
+    parts = repo_url.split('/')
+    if len(parts) < 5:
+        raise ValueError("無効なGitHubリポジトリURLです。例: https://github.com/username/repo")
+    owner = parts[-2]
+    repo = parts[-1]
+    return owner, repo
+
+
+def fetch_repo_files(owner: str, repo: str, path: str, ignore_patterns: list):
+    """
+    再帰的にリポジトリのファイル一覧を取得する。
+    ignore_patternsにマッチするディレクトリやファイルは取得しない。
+
+    GitHub API:
+      https://api.github.com/repos/{owner}/{repo}/contents/{path}
+    """
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    response = requests.get(api_url)
+    response.raise_for_status()
+    items = response.json()
+
+    all_files = []
+    for item in items:
+        item_path = item['path']
+
+        # ignoreパターンに一致する場合はスキップ
+        if is_ignored(item_path, ignore_patterns):
+            continue
+
+        if item['type']=='file':
+            all_files.append(item)
+        elif item['type']=='dir':
+            all_files.extend(fetch_repo_files(owner, repo, item_path, ignore_patterns))
+    return all_files
+
+
+def fetch_file_content(file_info: dict) -> str:
+    """
+    GitHub APIから取得したファイル情報からdownload_urlを使って内容をダウンロードし返す。
+    """
+    download_url = file_info.get('download_url')
+    if not download_url:
+        return ""
+    resp = requests.get(download_url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def merge_repo_code(repo_url: str, ignore_patterns: list) -> (str, str):
+    """
+    指定されたGitHubリポジトリURLからすべてのファイルを取得し、
+    ファイルごとにコメント行を挿入してまとめた文字列を返す。
+
+    Returns:
+        (repo_name, merged_text)
+         - repo_name: リポジトリ名(例: "requests")
+         - merged_text: すべてのファイル内容をまとめたテキスト
+    """
+    owner, repo_name = get_repo_owner_and_name(repo_url)
+    files = fetch_repo_files(owner, repo_name, "", ignore_patterns)
+
+    merged_chunks = []
+    for file_info in files:
+        path = file_info.get('path', 'unknown')
+        try:
+            content = fetch_file_content(file_info)
+        except Exception as e:
+            print(f"[Warning] {path} の取得に失敗: {e}")
+            continue
+
+        merged_chunks.append(f"\n\n# ===== File: {path} =====\n\n{content}")
+
+    return repo_name, "".join(merged_chunks)


### PR DESCRIPTION
This pull request introduces significant updates to the `repo-collector` project, including the addition of a `.collectignore` sample file, extensive documentation in `README.md`, and major enhancements to the codebase for handling repository file collection and ignoring specific patterns.

### Documentation and Configuration Updates:
* [`.collectignore.sample`](diffhunk://#diff-abac5781a65900d3b3a789a2ffb38acb0dbf75a1161182e39f96be2af607ba24R1-R5): Added a sample `.collectignore` file to specify patterns for files and directories to be ignored during the repository collection process.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R94): Expanded the documentation to include setup instructions, usage examples, directory structure, and a TODO list for future improvements.

### Codebase Enhancements:
* [`controller.py`](diffhunk://#diff-00066c2c6a38edb38037523eac2c0f6f4e2c7801786b691402bb684046b81956R1-R53): Added a new controller script to handle argument parsing and orchestrate the process of collecting and merging repository files, applying ignore patterns if specified.
* [`ignore_manager.py`](diffhunk://#diff-35fcfe67cf56afaa7c153a6072dd7d7baba160b43de9aeff5569ce91d0a06f54R1-R58): Introduced functions to load ignore patterns from a `.collectignore` file and check if a given path matches any of these patterns. This includes default ignore extensions for common binary files.
* [`services.py`](diffhunk://#diff-3ecba6be31877a5a2347c54e34b7afcc3e76575c6f6e194bcf70c336bdbe6075R1-R83): Refactored the service layer to handle GitHub API calls for fetching repository files and their contents, incorporating ignore patterns to exclude specified files and directories.

### Main Script Updates:
* `main.py` and `repo_collector.py`: Updated main scripts to utilize the new controller and services for fetching and merging repository files into a single text file, with improved handling of command-line arguments and ignore patterns. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R1-R16) [[2]](diffhunk://#diff-da359a7f38b33f6627fc82057bb015166f48544ced428ac75b529bf8e65310f4R1-R131)